### PR TITLE
Rename php-webdriver package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": ">=7.0",
-    "facebook/webdriver": "~1.0",
+    "php-webdriver/webdriver": "~1.0",
     "illuminate/support": "~5.5|^6.0",
     "browserstack/browserstack-local": "~1.1.0"
   },


### PR DESCRIPTION
Php-webdriver package [has been renamed](https://github.com/php-webdriver/php-webdriver/issues/730#issuecomment-575601572) and the original is now marked as abandoned (and will not receive any updates).

```sh
$ composer install
Package facebook/php-webdriver is abandoned, you should avoid using it. Use php-webdriver/webdriver instead.
```